### PR TITLE
fix(minimalism-bench): harden benchmark evidence and tool-loop accoun…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -156,6 +156,44 @@ Versions follow [Semantic Versioning](https://semver.org/).
   thresholds, transcript/report rendering, and sandbox teardown hygiene
   (forced failure and `SIGINT`). Model verdicts against live providers remain
   a separate, manually-gated exercise tracked on #285.
+- **`code-minimalism` eval harness hardening** (issue #336, follow-up to #285
+  WS2): the live WS2 evaluation exposed evidence-quality and lifecycle gaps in
+  `scripts/minimalism-bench.js`/`lib/helpers/minimalismBench.js`. Fixed:
+  cumulative token totals were the only signal a cell reported, hiding how
+  much of the total was retry/recovery cost rather than prompt size —
+  `collectCellMetrics()` now derives per-cell model request count, tool-call
+  and tool-error count, duplicate-call count, context-trim count, and the max
+  single-request input tokens from the same event stream, all new ledger/
+  report/transcript columns. The warm-up discard was asymmetric (arm A only,
+  since only arm A loads `code-minimalism`), biasing cache-sensitive results
+  toward arm A — `buildFixtureCellPlan()` now discards one warm-up per arm.
+  `runMatrix()` previously batched every ledger row and the report until the
+  whole matrix finished, so an interrupted run kept transcripts but no
+  ledger/report evidence — rows now append and the report re-renders after
+  every completed cell; a new `isMatrixComplete()` gate makes `renderReport()`
+  state "INCOMPLETE MATRIX" and withhold the verdict when any task/arm hasn't
+  hit its planned repeat count. A model that repeats an identical failing
+  tool call can rack up ~200s and >130k cumulative tokens before finally
+  succeeding once — the real agent's `tool-safety-middleware.js` loop-break
+  already caps this at 3 identical failures, but only *per turn*, so a model
+  that's told to stop, retries differently, and repeats the same failure in
+  a later turn was never bounded. `createBenchHostTools()` now tracks
+  identical tool failures across the WHOLE cell and, past
+  `DUPLICATE_FAILURE_BUDGET` (3), aborts the cell via the same
+  `getAbort`/`setAbort` `AbortController` handshake every provider loop
+  already honors — no changes to the real agent/tool-safety layer. The
+  ledger's new `outcome` column records `completed` vs.
+  `duplicate_failure_budget_exceeded(name,3x)` instead of collapsing the
+  recovery story into the final `correct` boolean alone. Finally, the
+  benchmark runs substantial real Aperio machinery (identity, skills,
+  preflight, middleware) even with its four-tool allowlist — a valid
+  "real Aperio agent" measurement, but not a clean isolated measurement of
+  the skill alone. A `skill-isolation` mode (minimal identity/middleware)
+  remains undecided/unbuilt; every row/report/transcript now carries an
+  explicit `mode` field (`EVAL_MODE`, currently always `"real-agent"`) so the
+  report states which mode produced a result rather than leaving it implicit.
+  18 new unit tests plus updates to the existing warm-up/report tests; all 60
+  unit + 14 integration tests green.
 - **Audit Run 1 — all 22 component slices complete** (A01–A22): every slice now
   has a content-hashed `manifest.json` and a `contract-result.json` with
   deterministic invariant checks. Completed slices span WebSocket/session lifecycle

--- a/id/reference/testing.md
+++ b/id/reference/testing.md
@@ -79,9 +79,12 @@ under `tests/unit/`, `tests/integration/`, and `tests/e2e/`.
 - `--dry-run` replays a deterministic mock script built from each fixture's
   `reference/` solution, exercising the whole pipeline (sandbox, metrics,
   ledger) in CI with no live model and no network
-- Live runs discard one warm-up repeat per fixture (a cold model/cache would
-  otherwise always land on arm A, which runs first — `buildFixtureCellPlan()`)
-  and alternate A/B/B/A across repeats to spread thermal/cache drift evenly
+- Live runs discard one warm-up repeat PER ARM (`buildFixtureCellPlan()`) — a
+  cold model/cache would otherwise always land on arm A, which runs first, but
+  arm A and arm B also load a different `skills/` tree (arm B's omits
+  `code-minimalism/`), so warming only one arm biases the other's cache/
+  latency numbers (issue #336) — and alternate A/B/B/A across repeats to
+  spread thermal/cache drift evenly
 - Live-run isolation is mandatory: use a dedicated llama-server port (default
   recommendation: `18080`, with `LLAMACPP_BASE_URL=http://127.0.0.1:18080`),
   a dedicated temporary runtime/log root outside the repository, and a
@@ -107,11 +110,42 @@ under `tests/unit/`, `tests/integration/`, and `tests/e2e/`.
   `output_tokens=0`) or when the readiness check fails.
 - The repository ledger path `var/autotune/minimalism.tsv` is reserved for
   dry-run/legacy compatibility only; live runs use one private ledger per
-  model, one row per task×arm×repeat;
+  model, one row per task×arm×repeat. Each row/`appendLedgerRow()` call is
+  written IMMEDIATELY after its cell completes (not batched until the whole
+  matrix finishes), and `renderReport()` re-renders after every row, so an
+  interrupted run keeps every cell it already paid for instead of discarding
+  it (issue #336). Beyond the token totals, each row also carries
+  `collectCellMetrics()`'s per-cell counts — model request count, tool-call
+  and tool-error count, duplicate-call count, context-trim count, and max
+  single-request input tokens — so a cell that spiraled through retries reads
+  differently from one that didn't, even at the same cumulative token total.
+  `isMatrixComplete(rows, fixtures, repeats)` gates the verdict: a partial
+  matrix (fewer rows than planned) reports "INCOMPLETE MATRIX" instead of
+  computing a verdict from an unfinished A/B comparison.
   `computeVerdict()` (`lib/helpers/minimalismBench.js`) applies the
   pre-registered KEEP/TRIM/DROP/INCONCLUSIVE rule to the medians — a
   correctness regression (by per-task *pass rate*, not an all-or-nothing
   gate) disqualifies a verdict no matter how good the token numbers look
+- A model that repeats an identical failing tool call can spiral for minutes
+  and >100k tokens before recovering — the real agent's own loop-break
+  (`tool-safety-middleware.js`) caps this at 3 identical failures, but only
+  *per turn*, so a model told to stop that retries differently and repeats
+  the same failure later was never bounded (issue #336). `createBenchHostTools()`
+  tracks identical tool failures across the WHOLE cell and, past
+  `DUPLICATE_FAILURE_BUDGET` (3), aborts the cell through the same
+  `getAbort`/`setAbort` `AbortController` handshake every provider loop
+  already honors — the real agent/tool-safety layer is untouched. The
+  ledger's `outcome` column records `completed` vs.
+  `duplicate_failure_budget_exceeded(name,Nx)` rather than only a final
+  `correct` boolean
+- Every row/report/transcript also carries a `mode` field (`EVAL_MODE` in
+  `lib/helpers/minimalismBench.js`, currently always `"real-agent"`) — the
+  benchmark runs substantial real Aperio machinery (identity, skills,
+  preflight, middleware) even behind its four-tool allowlist, which is a
+  valid "real agent" measurement but not a clean isolated measurement of the
+  skill alone. A `skill-isolation` mode remains an undecided, unbuilt design
+  question (issue #336); `mode` exists so a report states which measurement
+  produced a result instead of leaving it implicit
 - Run dry: `node scripts/minimalism-bench.js --dry-run [--tasks=id1,id2] [--repeats=N]`.
   Live runs name the model explicitly, for example:
   `node scripts/minimalism-bench.js --model=org/model:Q4_K_M --tasks=id1,id2 --repeats=3`.

--- a/lib/helpers/minimalismBench.js
+++ b/lib/helpers/minimalismBench.js
@@ -153,6 +153,40 @@ export function sumUsage(events) {
   return { input, output, net: input + output };
 }
 
+// ── Per-request/recovery metrics (issue #336) ───────────────────────────────
+//
+// sumUsage() answers "how many tokens total" but not "how many model round
+// trips did that cost, and how much of it was recovery from tool failure" —
+// a cell that retried a failing tool call a dozen times and one that got it
+// right first try can post the same cumulative total while representing very
+// different runs. These counts come from the same event stream sumUsage
+// already walks: one stream_end with usage == one model request; tool_call
+// events are recorded exclusively by this eval's own host tools (nothing
+// else in the agent loop emits that event type), so counting them here needs
+// no changes to the agent/tool-safety layers this eval sandboxes away from.
+export function collectCellMetrics(events) {
+  let requestCount = 0, toolCallCount = 0, toolErrorCount = 0, contextTrimCount = 0, maxInputTokens = 0;
+  let duplicateCallCount = 0;
+  const seenCalls = new Map();
+  for (const event of events ?? []) {
+    if (event?.type === "stream_end" && event.usage) {
+      requestCount++;
+      const inputTokens = Number(event.usage.input_tokens) || 0;
+      if (inputTokens > maxInputTokens) maxInputTokens = inputTokens;
+    } else if (event?.type === "tool_call") {
+      toolCallCount++;
+      if (typeof event.result === "string" && event.result.startsWith("❌")) toolErrorCount++;
+      const signature = `${event.name}:${JSON.stringify(event.args ?? {})}`;
+      const seen = (seenCalls.get(signature) || 0) + 1;
+      seenCalls.set(signature, seen);
+      if (seen > 1) duplicateCallCount++;
+    } else if (event?.type === "context_trimmed") {
+      contextTrimCount++;
+    }
+  }
+  return { requestCount, toolCallCount, toolErrorCount, duplicateCallCount, contextTrimCount, maxInputTokens };
+}
+
 // ── Correctness ───────────────────────────────────────────────────────────
 
 /**
@@ -201,11 +235,41 @@ export function runFixtureTests({ testsDir, solutionDir, timeoutMs = 30_000 }) {
   }
 }
 
+// ── Evaluation mode ──────────────────────────────────────────────────────
+//
+// The benchmark runs substantial real Aperio machinery even with the
+// four-tool allowlist — identity assembly, skill matching, preflight, the
+// full middleware stack (issue #336, finding 5). That's a valid "real Aperio
+// agent" measurement, but it is NOT a clean isolated measurement of
+// code-minimalism alone; a `skill-isolation` mode (minimal identity/
+// middleware, just the skill file and the bench tools) would be a different,
+// not-yet-built measurement. Until that exists, every run IS `real-agent` —
+// this constant exists so the report says so explicitly rather than leaving
+// the reader to assume, and so a future `skill-isolation` mode has a single
+// place to plug into (row/report/transcript already thread `mode` through).
+export const EVAL_MODE = "real-agent";
+
+// ── Bounded duplicate-failure policy ────────────────────────────────────────
+//
+// tool-safety-middleware.js already loop-breaks a SINGLE turn after 3
+// identical tool failures in a row, but the model can be told to stop, retry
+// a different way, get context-trimmed, and keep going — that loop-break
+// resets every turn, so nothing bounds the CELL as a whole. The live WS2 run
+// that exposed this (issue #336, gemma-4-26B-A4B repeating a failing
+// read_file call) took ~200s and >130k cumulative tokens on one cell before
+// the model finally got it right once. This budget counts identical tool
+// FAILURES across the whole cell, not per turn, and is enforced by the
+// benchmark's own host tools (see scripts/minimalism-bench.js), not by
+// touching the real agent's tool-safety layer.
+export const DUPLICATE_FAILURE_BUDGET = 3;
+
 // ── Ledger ────────────────────────────────────────────────────────────────
 
 export const LEDGER_COLUMNS = [
   "ts", "task", "arm", "repeat", "loc", "input_tokens", "output_tokens",
-  "net_tokens", "correct", "wall_ms", "model", "skill_sha",
+  "net_tokens", "request_count", "tool_call_count", "tool_error_count",
+  "duplicate_call_count", "context_trim_count", "max_input_tokens",
+  "correct", "outcome", "wall_ms", "model", "mode", "skill_sha",
 ];
 
 export function formatLedgerRow(row) {
@@ -253,6 +317,18 @@ function groupBy(rows, arm, task) {
   return rows.filter(r => r.task === task && r.arm === arm);
 }
 
+/**
+ * True once every fixture has at least `repeats` recorded rows on both arms.
+ * `fixtures` is the loaded fixture list (each with an `.id` matching `row.task`),
+ * so this reflects what the run PLANNED to record, not just what's in `rows` —
+ * an interrupted run has fewer rows than planned and must read as incomplete,
+ * not silently pass because the rows it does have look internally consistent.
+ */
+export function isMatrixComplete(rows, fixtures, repeats) {
+  return fixtures.every(fixture =>
+    ["A", "B"].every(arm => groupBy(rows, arm, fixture.id).length >= repeats));
+}
+
 // ── Transcripts + report ─────────────────────────────────────────────────
 //
 // The ledger's TSV rows are enough to compute a verdict but not to see what
@@ -268,10 +344,12 @@ export function renderTranscript(meta, events) {
   const lines = [
     `# ${meta.task} / arm ${meta.arm} / repeat ${meta.repeat}${meta.discard ? " (discarded warm-up)" : ""}`,
     "",
-    `- model: \`${meta.model}\``,
+    `- model: \`${meta.model}\` (mode: ${meta.mode ?? EVAL_MODE})`,
     `- correct: ${meta.correct ? "yes" : "no"}`,
+    `- outcome: ${meta.outcome ?? "completed"}`,
     `- loc delta: ${meta.loc}`,
-    `- tokens: input=${meta.inputTokens} output=${meta.outputTokens} net=${meta.netTokens}`,
+    `- tokens: input=${meta.inputTokens} output=${meta.outputTokens} net=${meta.netTokens} (max single-request input=${meta.maxInputTokens ?? 0})`,
+    `- requests: ${meta.requestCount ?? 0}, tool calls: ${meta.toolCallCount ?? 0} (errors: ${meta.toolErrorCount ?? 0}, duplicates: ${meta.duplicateCallCount ?? 0}), context trims: ${meta.contextTrimCount ?? 0}`,
     `- wall time: ${meta.wallMs}ms`,
     "",
     "## Prompt",
@@ -293,27 +371,42 @@ export function renderTranscript(meta, events) {
   return lines.join("\n");
 }
 
-/** Human-readable summary of a completed matrix run: per task/arm medians + the pre-registered verdict. */
-export function renderReport(rows) {
+/**
+ * Human-readable summary of a matrix run: per task/arm medians + the
+ * pre-registered verdict. `{ fixtures, repeats }` is the run's PLAN — when
+ * given, an incomplete matrix (fewer rows than planned, e.g. an interrupted
+ * run) reports as incomplete and withholds the verdict instead of computing
+ * one from a partial A/B comparison. Omitting it (existing unit-test call
+ * shape, and any caller with no independent notion of what was planned)
+ * keeps the old behavior: the verdict reflects whatever rows were given.
+ */
+export function renderReport(rows, { fixtures, repeats } = {}) {
   const tasks = [...new Set(rows.map(r => r.task))].sort();
   const lines = [
     "# Minimalism-bench report",
     "",
-    `Generated ${new Date().toISOString()} — ${rows.length} recorded cells, model \`${rows[0]?.model ?? "(none)"}\`.`,
+    `Generated ${new Date().toISOString()} — ${rows.length} recorded cells, model \`${rows[0]?.model ?? "(none)"}\`, mode \`${rows[0]?.mode ?? EVAL_MODE}\`.`,
     "",
-    "| Task | Arm | Correct | Med. input | Med. output | Med. net | Med. wall (ms) |",
-    "|---|---|---|---|---|---|---|",
+    "| Task | Arm | Correct | Aborted | Med. input | Med. output | Med. net | Med. req | Med. tool-err | Med. dup | Med. ctx-trim | Med. wall (ms) |",
+    "|---|---|---|---|---|---|---|---|---|---|---|---|",
   ];
   for (const task of tasks) {
     for (const arm of ["A", "B"]) {
       const cellRows = groupBy(rows, arm, task);
       if (!cellRows.length) continue;
       const correct = cellRows.reduce((sum, r) => sum + (r.correct ? 1 : 0), 0);
+      const aborted = cellRows.reduce((sum, r) => sum + (r.outcome && r.outcome !== "completed" ? 1 : 0), 0);
       const med = key => median(cellRows.map(r => Number(r[key])));
-      lines.push(`| ${task} | ${arm} | ${correct}/${cellRows.length} | ${med("input_tokens")} | ${med("output_tokens")} | ${med("net_tokens")} | ${med("wall_ms")} |`);
+      lines.push(`| ${task} | ${arm} | ${correct}/${cellRows.length} | ${aborted}/${cellRows.length} | ${med("input_tokens")} | ${med("output_tokens")} | ${med("net_tokens")} | ${med("request_count")} | ${med("tool_error_count")} | ${med("duplicate_call_count")} | ${med("context_trim_count")} | ${med("wall_ms")} |`);
     }
   }
-  lines.push("", `**Verdict: ${rows.length ? computeVerdict(rows) : "N/A (no rows)"}**`);
+  const complete = !fixtures || isMatrixComplete(rows, fixtures, repeats);
+  if (!complete) {
+    const expected = fixtures.length * repeats * 2;
+    lines.push("", `**INCOMPLETE MATRIX — ${rows.length}/${expected} expected cells recorded. Verdict withheld until every task has ${repeats} repeats on both arms.**`);
+  } else {
+    lines.push("", `**Verdict: ${rows.length ? computeVerdict(rows) : "N/A (no rows)"}**`);
+  }
   return lines.join("\n");
 }
 

--- a/scripts/minimalism-bench.js
+++ b/scripts/minimalism-bench.js
@@ -23,8 +23,9 @@ import { createAgent } from "../lib/agent.js";
 import { makeSinkEmitter } from "../lib/emitters/sinkEmitter.js";
 import { runWithPaths } from "../lib/routes/paths.js";
 import {
-  REPO_ROOT, buildSandbox, sha256File, snapshotDir, locDelta, sumUsage,
-  runFixtureTests, appendLedgerRow, computeVerdict, renderTranscript, renderReport,
+  REPO_ROOT, buildSandbox, sha256File, snapshotDir, locDelta, sumUsage, collectCellMetrics,
+  runFixtureTests, appendLedgerRow, computeVerdict, isMatrixComplete, renderTranscript, renderReport,
+  DUPLICATE_FAILURE_BUDGET, EVAL_MODE,
 } from "../lib/helpers/minimalismBench.js";
 import {
   LIVE_EVAL_BASE_URL, createLiveEvalPaths, waitForLlamaReadiness,
@@ -118,7 +119,14 @@ export function buildBenchPrompt(fixture) {
 // stream_start/token/stream_end events, so a transcript built from that
 // stream sees tool calls and assistant turns in the order they actually
 // happened, not two separately-ordered lists.
-export function createBenchHostTools(workspaceDir, emitter = null) {
+//
+// `onDuplicateFailureBudgetExceeded` (optional) fires once a given tool
+// call's (name, args) signature has failed DUPLICATE_FAILURE_BUDGET times
+// across the WHOLE cell — not per turn, unlike tool-safety-middleware's own
+// loop-break, which resets every turn and so never bounds a model that gets
+// stopped, retries a different way, and repeats the same failure again in a
+// later turn (issue #336).
+export function createBenchHostTools(workspaceDir, emitter = null, { onDuplicateFailureBudgetExceeded } = {}) {
   // A raw prefix check (`abs.startsWith(workspaceDir + "/")`) breaks on
   // Windows, where resolve() returns backslash-separated paths — relative()
   // is the platform-correct containment check on both POSIX and Windows.
@@ -141,9 +149,20 @@ export function createBenchHostTools(workspaceDir, emitter = null) {
     }
     return null;
   };
+  const failureSignatureCounts = new Map();
+  let budgetTripped = false;
   const record = (name, args, result) => {
     const displayArgs = args?.path ? { ...args, path: displayPath(args.path) } : args;
     emitter?.send({ type: "tool_call", name, args: displayArgs, result });
+    if (!budgetTripped && typeof result === "string" && result.startsWith("❌")) {
+      const signature = `${name}:${JSON.stringify(args ?? {})}`;
+      const count = (failureSignatureCounts.get(signature) || 0) + 1;
+      failureSignatureCounts.set(signature, count);
+      if (count >= DUPLICATE_FAILURE_BUDGET) {
+        budgetTripped = true;
+        onDuplicateFailureBudgetExceeded?.({ name, args, count });
+      }
+    }
     return result;
   };
   return [
@@ -204,21 +223,38 @@ async function runOneCell({ fixture, arm, repeat, dryRun, skillSha, model, disca
     // re-interleave by guesswork.
     const sink = makeSinkEmitter();
     const providerConfig = dryRun ? { name: "mock", script: buildMockScript(fixture) } : { name: provider, model };
+    // The provider loops store their in-flight AbortController here via
+    // setAbort() every request and check getAbort()?.signal?.aborted at the
+    // top of the next iteration (see e.g. lib/agent/providers/llamacpp.js) —
+    // the same mechanism a UI "stop" button uses. Tripping the duplicate-
+    // failure budget below calls .abort() on whatever's currently stored,
+    // which lands between the failing tool call and the loop's next request.
+    const abortBox = { controller: null };
+    let duplicateFailureBudget = null;
     const agent = await createAgent({
       root: sandbox.root,
       version: "1.0.0-minimalism-bench",
       providerConfig,
       spec: { id: "minimalism-bench", toolAllowlist: BENCH_TOOL_ALLOWLIST },
-      hostTools: createBenchHostTools(sandbox.workspaceDir, sink.emitter),
+      hostTools: createBenchHostTools(sandbox.workspaceDir, sink.emitter, {
+        onDuplicateFailureBudgetExceeded: (info) => {
+          duplicateFailureBudget = info;
+          abortBox.controller?.abort();
+        },
+      }),
     });
     const messages = [{ role: "user", content: buildBenchPrompt(fixture) }];
     const startedAt = Date.now();
     await runWithPaths([sandbox.root], [sandbox.root], sandbox.workspaceDir, () =>
-      agent.runAgentLoop(messages, sink.emitter, {}, () => null, () => {}));
+      agent.runAgentLoop(messages, sink.emitter, {}, () => abortBox.controller, (c) => { abortBox.controller = c; }));
     const wallMs = Date.now() - startedAt;
+    const outcome = duplicateFailureBudget
+      ? `duplicate_failure_budget_exceeded(${duplicateFailureBudget.name},${duplicateFailureBudget.count}x)`
+      : "completed";
 
     const after = snapshotDir(sandbox.workspaceDir);
     const usage = sumUsage(sink.events);
+    const metrics = collectCellMetrics(sink.events);
     const correct = runFixtureTests({ testsDir: fixture.testsDir, solutionDir: sandbox.workspaceDir });
     const loc = locDelta(before, after);
 
@@ -231,9 +267,17 @@ async function runOneCell({ fixture, arm, repeat, dryRun, skillSha, model, disca
       input_tokens: usage.input,
       output_tokens: usage.output,
       net_tokens: usage.net,
+      request_count: metrics.requestCount,
+      tool_call_count: metrics.toolCallCount,
+      tool_error_count: metrics.toolErrorCount,
+      duplicate_call_count: metrics.duplicateCallCount,
+      context_trim_count: metrics.contextTrimCount,
+      max_input_tokens: metrics.maxInputTokens,
       correct,
+      outcome,
       wall_ms: wallMs,
       model: agent.provider?.model ?? "",
+      mode: EVAL_MODE,
       skill_sha: skillSha,
     };
     // A discarded warm-up exists only to pay the cold model-load/cache cost
@@ -242,7 +286,14 @@ async function runOneCell({ fixture, arm, repeat, dryRun, skillSha, model, disca
 
     if (transcriptDir) {
       mkdirSync(transcriptDir, { recursive: true });
-      const meta = { task: fixture.id, arm, repeat, discard, model: row.model, correct, loc, inputTokens: usage.input, outputTokens: usage.output, netTokens: usage.net, wallMs, prompt: fixture.prompt };
+      const meta = {
+        task: fixture.id, arm, repeat, discard, model: row.model, mode: row.mode, correct, outcome, loc,
+        inputTokens: usage.input, outputTokens: usage.output, netTokens: usage.net,
+        requestCount: metrics.requestCount, toolCallCount: metrics.toolCallCount,
+        toolErrorCount: metrics.toolErrorCount, duplicateCallCount: metrics.duplicateCallCount,
+        contextTrimCount: metrics.contextTrimCount, maxInputTokens: metrics.maxInputTokens,
+        wallMs, prompt: fixture.prompt,
+      };
       const transcriptPath = join(transcriptDir, `${fixture.id}-${arm}-repeat${repeat}${discard ? "-warmup" : ""}.md`);
       writeFileSync(transcriptPath, renderTranscript(meta, sink.events), "utf8");
     }
@@ -264,20 +315,23 @@ export function buildRunPlan(repeats) {
 }
 
 /**
- * Per-fixture cell plan: a discarded warm-up (live runs only) ahead of the
- * recorded A/B/B/A matrix. Without it, the first measured cell for every
- * fixture is always arm A on a cold model/cache (arm A always runs first —
- * see buildRunPlan), biasing the comparison in arm B's favor. The mock
- * provider has no cache/thermal state, so a dry run skips the warm-up.
+ * Per-fixture cell plan: a discarded warm-up per arm (live runs only) ahead
+ * of the recorded A/B/B/A matrix. Arm A and arm B load a DIFFERENT skills/
+ * tree (code-minimalism/ present vs. removed — see buildSandbox), so they
+ * warm a different prompt cache; warming only arm A (the original approach)
+ * left arm B measured cold on every fixture, biasing latency/cache-sensitive
+ * results in arm A's favor. Warming both arms independently keeps the
+ * treatment symmetric. The mock provider has no cache/thermal state, so a
+ * dry run skips both warm-ups.
  */
 export function buildFixtureCellPlan({ dryRun, repeats }) {
   const plan = [];
-  if (!dryRun) plan.push({ repeat: 0, arm: "A", discard: true });
+  if (!dryRun) plan.push({ repeat: 0, arm: "A", discard: true }, { repeat: 0, arm: "B", discard: true });
   for (const cell of buildRunPlan(repeats)) plan.push({ ...cell, discard: false });
   return plan;
 }
 
-export async function runMatrix({ dryRun, taskIds, repeats, model = process.env.LLAMACPP_MODEL, ledgerPath = LEDGER_PATH, live = {}, provider = "llamacpp" }) {
+export async function runMatrix({ dryRun, taskIds, repeats, model = process.env.LLAMACPP_MODEL, ledgerPath = LEDGER_PATH, live = {}, provider = "llamacpp", verdict = false }) {
   if (dryRun) {
     // The mock provider refuses to resolve outside NODE_ENV=test
     // (lib/providers/index.js) — set it rather than silently falling through
@@ -317,6 +371,11 @@ export async function runMatrix({ dryRun, taskIds, repeats, model = process.env.
       for (const cell of buildFixtureCellPlan({ dryRun, repeats })) cellPlan.push({ fixture, ...cell });
     }
 
+    // Each completed cell is appended to the ledger and the report re-rendered
+    // IMMEDIATELY, not batched until the whole matrix finishes — an
+    // interrupted run (killed, crashed, out of budget) otherwise has
+    // transcripts on disk but no ledger row and no report for the cells it
+    // did complete, discarding real (and expensive) evidence.
     const rows = [];
     let index = 0;
     for (const { fixture, repeat, arm, discard } of cellPlan) {
@@ -325,14 +384,21 @@ export async function runMatrix({ dryRun, taskIds, repeats, model = process.env.
         fixture, arm, repeat, dryRun, skillSha, model, discard, transcriptDir,
         progress: { index, total: cellPlan.length }, provider,
       });
-      if (!discard) rows.push(row);
+      if (!discard) {
+        rows.push(row);
+        appendLedgerRow(outputLedger, row);
+        writeFileSync(reportPath, renderReport(rows, { fixtures, repeats }), "utf8");
+      }
     }
 
-    for (const row of rows) appendLedgerRow(outputLedger, row);
-    if (rows.length) writeFileSync(reportPath, renderReport(rows), "utf8");
     console.log(`[minimalism-bench] ledger:      ${outputLedger}`);
     console.log(`[minimalism-bench] report:      ${reportPath}`);
     console.log(`[minimalism-bench] transcripts: ${transcriptDir}`);
+    if (verdict) {
+      console.log(isMatrixComplete(rows, fixtures, repeats)
+        ? computeVerdict(rows)
+        : `INCOMPLETE — ${rows.length}/${fixtures.length * repeats * 2} expected cells recorded, verdict withheld`);
+    }
     return rows;
   } finally {
     if (!dryRun && !isCloud) {
@@ -368,8 +434,7 @@ async function main() {
       liveInfo.baseURL = `http://127.0.0.1:8080`;
       liveInfo.fetchImpl = globalThis.fetch;
     }
-    const rows = await runMatrix({ dryRun: args.dryRun, taskIds: args.tasks, repeats: args.repeats, model: args.model, ledgerPath: liveHandle?.ledgerPath, live: liveInfo, provider: args.provider });
-    if (args.verdict) console.log(computeVerdict(rows));
+    await runMatrix({ dryRun: args.dryRun, taskIds: args.tasks, repeats: args.repeats, model: args.model, ledgerPath: liveHandle?.ledgerPath, live: liveInfo, provider: args.provider, verdict: args.verdict });
   } finally {
     if (!args.existingServer && !isCloudProvider) await teardownLiveEval(liveHandle);
   }

--- a/tests/unit/helpers/minimalism-bench.test.js
+++ b/tests/unit/helpers/minimalism-bench.test.js
@@ -8,8 +8,8 @@ import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 
 import {
-  countSourceLoc, locDelta, sumUsage, runFixtureTests, median, medianAbsoluteDeviation, computeVerdict,
-  renderTranscript, renderReport, REPO_ROOT,
+  countSourceLoc, locDelta, sumUsage, collectCellMetrics, runFixtureTests, median, medianAbsoluteDeviation,
+  computeVerdict, isMatrixComplete, renderTranscript, renderReport, REPO_ROOT, DUPLICATE_FAILURE_BUDGET, EVAL_MODE,
 } from "../../../lib/helpers/minimalismBench.js";
 import { buildRunPlan, buildFixtureCellPlan, buildBenchPrompt, BENCH_TOOL_ALLOWLIST, createBenchHostTools } from "../../../scripts/minimalism-bench.js";
 import {
@@ -188,6 +188,52 @@ describe("E2 — token accounting", () => {
   });
 });
 
+describe("collectCellMetrics — per-request/recovery counts (issue #336)", () => {
+  test("counts requests, tool calls/errors, duplicate calls, context trims, and the max single-request input", () => {
+    const events = [
+      { type: "stream_end", usage: { input_tokens: 100, output_tokens: 20 } },
+      { type: "tool_call", name: "read_file", args: { path: "a.js" }, result: "❌ a.js not found" },
+      { type: "tool_call", name: "read_file", args: { path: "a.js" }, result: "❌ a.js not found" },
+      { type: "context_trimmed", dropped: 2, pct: 0.3 },
+      { type: "stream_end", usage: { input_tokens: 4000, output_tokens: 30 } },
+      { type: "tool_call", name: "write_file", args: { path: "a.js", content: "x" }, result: "wrote a.js" },
+    ];
+    assert.deepEqual(collectCellMetrics(events), {
+      requestCount: 2,
+      toolCallCount: 3,
+      toolErrorCount: 2,
+      duplicateCallCount: 1,
+      contextTrimCount: 1,
+      maxInputTokens: 4000,
+    });
+  });
+
+  test("empty/missing events produce all-zero metrics, never NaN or a throw", () => {
+    assert.deepEqual(collectCellMetrics([]), {
+      requestCount: 0, toolCallCount: 0, toolErrorCount: 0,
+      duplicateCallCount: 0, contextTrimCount: 0, maxInputTokens: 0,
+    });
+    assert.deepEqual(collectCellMetrics(undefined), {
+      requestCount: 0, toolCallCount: 0, toolErrorCount: 0,
+      duplicateCallCount: 0, contextTrimCount: 0, maxInputTokens: 0,
+    });
+  });
+
+  test("a third identical call counts as a second duplicate, not capped at one", () => {
+    const events = [
+      { type: "tool_call", name: "read_file", args: { path: "a.js" }, result: "❌ not found" },
+      { type: "tool_call", name: "read_file", args: { path: "a.js" }, result: "❌ not found" },
+      { type: "tool_call", name: "read_file", args: { path: "a.js" }, result: "❌ not found" },
+    ];
+    assert.equal(collectCellMetrics(events).duplicateCallCount, 2);
+  });
+
+  test("stream_end frames without usage do not count as a request", () => {
+    const events = [{ type: "stream_end", text: "done" }];
+    assert.equal(collectCellMetrics(events).requestCount, 0);
+  });
+});
+
 describe("E2 — correctness runner reports honest failure", () => {
   const testsDir = join(FIXTURE("slug-helper"), "tests");
 
@@ -328,11 +374,13 @@ describe("scripts/minimalism-bench.js — warm-up discard", () => {
     assert.deepEqual(plan.map(c => c.arm), buildRunPlan(2).map(c => c.arm));
   });
 
-  test("a live run's first cell is a discarded arm-A warm-up, ahead of the recorded matrix", () => {
+  test("a live run's first two cells are discarded warm-ups, one per arm, ahead of the recorded matrix", () => {
     const plan = buildFixtureCellPlan({ dryRun: false, repeats: 3 });
     assert.equal(plan[0].discard, true);
     assert.equal(plan[0].arm, "A");
-    assert.deepEqual(plan.slice(1), buildRunPlan(3).map(c => ({ ...c, discard: false })));
+    assert.equal(plan[1].discard, true);
+    assert.equal(plan[1].arm, "B");
+    assert.deepEqual(plan.slice(2), buildRunPlan(3).map(c => ({ ...c, discard: false })));
   });
 });
 
@@ -436,6 +484,73 @@ describe("scripts/minimalism-bench.js — cross-platform workspace containment",
   });
 });
 
+describe("createBenchHostTools — bounded duplicate-failure policy (issue #336)", () => {
+  test("the same failing call repeated DUPLICATE_FAILURE_BUDGET times trips the callback exactly once, with the offending name/args/count", async () => {
+    const workspaceDir = mkdtempSync(join(tmpdir(), "minimalism-safe-"));
+    try {
+      const trips = [];
+      const tools = createBenchHostTools(workspaceDir, null, {
+        onDuplicateFailureBudgetExceeded: (info) => trips.push(info),
+      });
+      const readFile = tools.find(t => t.name === "read_file");
+      for (let i = 0; i < DUPLICATE_FAILURE_BUDGET + 2; i++) {
+        await readFile.handler({ path: "missing.js" });
+      }
+      assert.equal(trips.length, 1, "callback must fire exactly once, not once per call past the budget");
+      assert.equal(trips[0].name, "read_file");
+      assert.deepEqual(trips[0].args, { path: "missing.js" });
+      assert.equal(trips[0].count, DUPLICATE_FAILURE_BUDGET);
+    } finally {
+      rmSync(workspaceDir, { recursive: true, force: true });
+    }
+  });
+
+  test("failures with DIFFERENT args never trip the budget, even past the count — only an identical signature counts", async () => {
+    const workspaceDir = mkdtempSync(join(tmpdir(), "minimalism-safe-"));
+    try {
+      const trips = [];
+      const tools = createBenchHostTools(workspaceDir, null, {
+        onDuplicateFailureBudgetExceeded: (info) => trips.push(info),
+      });
+      const readFile = tools.find(t => t.name === "read_file");
+      for (let i = 0; i < DUPLICATE_FAILURE_BUDGET + 2; i++) {
+        await readFile.handler({ path: `missing-${i}.js` });
+      }
+      assert.equal(trips.length, 0);
+    } finally {
+      rmSync(workspaceDir, { recursive: true, force: true });
+    }
+  });
+
+  test("a successful call never counts toward the failure budget", async () => {
+    const workspaceDir = mkdtempSync(join(tmpdir(), "minimalism-safe-"));
+    try {
+      const trips = [];
+      const writeFile = createBenchHostTools(workspaceDir, null, {
+        onDuplicateFailureBudgetExceeded: (info) => trips.push(info),
+      }).find(t => t.name === "write_file");
+      for (let i = 0; i < DUPLICATE_FAILURE_BUDGET + 2; i++) {
+        await writeFile.handler({ path: "a.js", content: "x" });
+      }
+      assert.equal(trips.length, 0);
+    } finally {
+      rmSync(workspaceDir, { recursive: true, force: true });
+    }
+  });
+
+  test("no callback given — repeated failures still work, nothing throws", async () => {
+    const workspaceDir = mkdtempSync(join(tmpdir(), "minimalism-safe-"));
+    try {
+      const readFile = createBenchHostTools(workspaceDir).find(t => t.name === "read_file");
+      for (let i = 0; i < DUPLICATE_FAILURE_BUDGET + 2; i++) {
+        await readFile.handler({ path: "missing.js" });
+      }
+    } finally {
+      rmSync(workspaceDir, { recursive: true, force: true });
+    }
+  });
+});
+
 describe("renderTranscript — human-readable per-cell conversation", () => {
   const meta = {
     task: "slug-helper", arm: "A", repeat: 1, discard: false, model: "test-model",
@@ -473,6 +588,30 @@ describe("renderTranscript — human-readable per-cell conversation", () => {
   });
 });
 
+describe("evaluation mode is reported, not left implicit (issue #336, finding 5)", () => {
+  test("EVAL_MODE is the current single execution path, real-agent — no skill-isolation path exists yet", () => {
+    assert.equal(EVAL_MODE, "real-agent");
+  });
+
+  test("renderTranscript states the mode a row-less caller would otherwise have to assume", () => {
+    const md = renderTranscript({ task: "t", arm: "A", repeat: 1, model: "m", mode: "real-agent", correct: true, loc: 0, prompt: "p" }, []);
+    assert.match(md, /mode: real-agent/);
+  });
+
+  test("renderTranscript falls back to EVAL_MODE when no mode is given (existing call shape)", () => {
+    const md = renderTranscript({ task: "t", arm: "A", repeat: 1, model: "m", correct: true, loc: 0, prompt: "p" }, []);
+    assert.match(md, new RegExp(`mode: ${EVAL_MODE}`));
+  });
+
+  test("renderReport's header states the mode of the rows it summarizes", () => {
+    const rows = [
+      { task: "t1", arm: "A", repeat: 1, loc: 0, input_tokens: 1, output_tokens: 1, net_tokens: 2, correct: true, wall_ms: 1, model: "m", mode: "real-agent" },
+    ];
+    const md = renderReport(rows);
+    assert.match(md, /mode `real-agent`/);
+  });
+});
+
 describe("renderReport — human-readable run summary", () => {
   const row = (task, arm, repeat, overrides = {}) => ({
     task, arm, repeat, loc: 0, input_tokens: 1000, output_tokens: 200, net_tokens: 1200,
@@ -493,6 +632,55 @@ describe("renderReport — human-readable run summary", () => {
   test("no rows — reports N/A rather than crashing on an empty matrix", () => {
     const md = renderReport([]);
     assert.match(md, /\*\*Verdict: N\/A/);
+  });
+
+  test("no {fixtures, repeats} given — verdict computed from whatever rows exist (existing call shape)", () => {
+    const rows = [row("slug-helper", "A", 1), row("slug-helper", "B", 1)];
+    const md = renderReport(rows);
+    assert.match(md, new RegExp(`\\*\\*Verdict: ${computeVerdict(rows)}\\*\\*`));
+  });
+
+  test("an interrupted run (fewer rows than planned) reports incomplete and withholds the verdict", () => {
+    const rows = [row("slug-helper", "A", 1), row("slug-helper", "B", 1)]; // repeats=3 planned, only repeat 1 landed
+    const fixtures = [{ id: "slug-helper" }];
+    const md = renderReport(rows, { fixtures, repeats: 3 });
+    assert.match(md, /INCOMPLETE MATRIX/);
+    assert.match(md, /2\/6 expected cells/);
+    assert.doesNotMatch(md, /\*\*Verdict:/);
+  });
+
+  test("a complete matrix ({fixtures, repeats} given, every task/arm has enough repeats) shows the verdict", () => {
+    const rows = [
+      row("slug-helper", "A", 1), row("slug-helper", "A", 2),
+      row("slug-helper", "B", 1), row("slug-helper", "B", 2),
+    ];
+    const fixtures = [{ id: "slug-helper" }];
+    const md = renderReport(rows, { fixtures, repeats: 2 });
+    assert.match(md, new RegExp(`\\*\\*Verdict: ${computeVerdict(rows)}\\*\\*`));
+    assert.doesNotMatch(md, /INCOMPLETE/);
+  });
+});
+
+describe("isMatrixComplete — plan-aware completeness (issue #336)", () => {
+  const r = (task, arm, repeat) => ({ task, arm, repeat, loc: 0, correct: true });
+
+  test("every fixture with both arms at the planned repeat count is complete", () => {
+    const fixtures = [{ id: "t1" }, { id: "t2" }];
+    const rows = ["t1", "t2"].flatMap(task => ["A", "B"].flatMap(arm => [r(task, arm, 1), r(task, arm, 2)]));
+    assert.equal(isMatrixComplete(rows, fixtures, 2), true);
+  });
+
+  test("one fixture missing a repeat on one arm is incomplete", () => {
+    const fixtures = [{ id: "t1" }, { id: "t2" }];
+    const rows = [
+      r("t1", "A", 1), r("t1", "A", 2), r("t1", "B", 1), r("t1", "B", 2),
+      r("t2", "A", 1), r("t2", "A", 2), r("t2", "B", 1), // t2/B missing repeat 2
+    ];
+    assert.equal(isMatrixComplete(rows, fixtures, 2), false);
+  });
+
+  test("no rows at all against a non-empty plan is incomplete", () => {
+    assert.equal(isMatrixComplete([], [{ id: "t1" }], 2), false);
   });
 });
 


### PR DESCRIPTION
…ting

The live WS2 evaluation (#285) with gemma-4-26B-A4B and Qwen2.5-Coder-14B exposed evidence-quality and lifecycle gaps in the code-minimalism eval harness:

- Token totals were cumulative but presented as prompt cost, with no way to see how much of a cell's tokens were retry/recovery rather than prompt size. collectCellMetrics() now derives per-cell model request count, tool-call/error count, duplicate-call count, context-trim count, and max single-request input tokens from the same event stream, all new ledger/report/transcript fields.
- The warm-up discard was asymmetric: only arm A (which loads code-minimalism) got a cache warm-up, biasing cache-sensitive results in its favor. buildFixtureCellPlan() now discards one warm-up per arm.
- runMatrix() batched every ledger row and the report.md until the whole matrix finished, so an interrupted run kept transcripts but no ledger or report evidence. Rows now append and the report re-renders after every completed cell; isMatrixComplete() gates renderReport() so a partial matrix reports INCOMPLETE and withholds the verdict instead of computing one from an unfinished A/B comparison.
- A model repeating an identical failing tool call could spiral for ~200s and >130k cumulative tokens before recovering once. The real agent's tool-safety-middleware loop-break already caps this at 3 identical failures, but only per turn, so a model told to stop that retries differently and repeats the same failure later was never bounded. createBenchHostTools() now tracks identical failures across the WHOLE cell and, past DUPLICATE_FAILURE_BUDGET (3), aborts the cell via the same getAbort/setAbort AbortController handshake every provider loop already honors -- no changes to the real agent/tool-safety layer. The ledger's new outcome column records completed vs. duplicate_failure_budget_exceeded(name,3x) instead of collapsing the recovery story into the final correct boolean.
- The benchmark runs substantial real Aperio machinery even behind its four-tool allowlist -- a valid "real agent" measurement but not an isolated one. Every row/report/transcript now carries an explicit mode field (EVAL_MODE, currently always "real-agent"); a skill-isolation mode remains a deliberately undecided design question, tracked on the issue.

18 new unit tests plus updates to the existing warm-up/report tests; all 60 unit + 14 integration tests green (dry-run, ledger typing, hygiene, SIGINT teardown).

Fixes #336. Follow-up to #285 WS2.